### PR TITLE
feat: make TawQuest wemembew its windows and tame the audio, nya

### DIFF
--- a/HttpData/AppData/index.html
+++ b/HttpData/AppData/index.html
@@ -54,6 +54,21 @@
                 <option value="apitest">APITest</option>
             </select>
         </div>
+        <div class="audio-volume-selector">
+            <label class="audio-volume-label" for="audioVolume"><b>VOLUME</b> </label>
+            <input
+                class="audio-volume"
+                id="audioVolume"
+                type="range"
+                min="0"
+                max="100"
+                step="1"
+                value="100"
+                aria-label="Game audio volume"
+                title="Game audio volume"
+            >
+            <span hidden id="audioVolumeValue" class="audio-volume-value"></span>
+        </div>
     </div>
 
 <!----------------------------------------- Body --------------------------------------->
@@ -109,6 +124,7 @@
     <script src="../AppData/scripts/tardboard.js"></script>
     <script src="../AppData/scripts/tardtest.js"></script>
     <script src="../AppData/scripts/apitest.js"></script>
+    <script src="../AppData/scripts/audio.js"></script>
     <script src="https://milklounge.wang/tardquest/devtools.js"></script>
     <script src="../AppData/scripts/windowfocus.js"></script>
 </body>

--- a/HttpData/AppData/scripts/audio-bridge.js
+++ b/HttpData/AppData/scripts/audio-bridge.js
@@ -1,0 +1,146 @@
+(() => {
+    const gamePath = window.location.pathname;
+    const isGameDocument =
+        /\/GameData\/game\.html$/.test(gamePath)
+
+    if (!isGameDocument || window.__tardquestAudioBridgeInstalled) {
+        return;
+    }
+
+    window.__tardquestAudioBridgeInstalled = true;
+
+    let masterVolume = 1;
+    const clampVolume = value => Math.min(1, Math.max(0, Number(value) || 0));
+
+    const mediaVolume = Object.getOwnPropertyDescriptor(
+        HTMLMediaElement.prototype,
+        "volume"
+    );
+    const mediaPlay = HTMLMediaElement.prototype.play;
+    const mediaBaseVolumes = new WeakMap();
+    const trackedMedia = new Set();
+
+    const applyMediaVolume = audio => {
+        const baseVolume = mediaBaseVolumes.get(audio) ?? mediaVolume.get.call(audio);
+        mediaVolume.set.call(audio, clampVolume(baseVolume) * masterVolume);
+    };
+
+    const rememberMediaVolume = audio => {
+        if (!mediaBaseVolumes.has(audio)) {
+            mediaBaseVolumes.set(audio, clampVolume(mediaVolume.get.call(audio)));
+        }
+        trackedMedia.add(audio);
+    };
+
+    const registerMedia = audio => {
+        if (!(audio instanceof HTMLMediaElement)) {
+            return;
+        }
+
+        rememberMediaVolume(audio);
+        applyMediaVolume(audio);
+    };
+
+    const registerCollection = collection => {
+        if (!collection || typeof collection !== "object") {
+            return;
+        }
+
+        Object.values(collection).forEach(entry => {
+            registerMedia(entry?.audio ?? entry);
+        });
+    };
+
+    if (mediaVolume?.get && mediaVolume?.set && typeof mediaPlay === "function") {
+        Object.defineProperty(HTMLMediaElement.prototype, "volume", {
+            configurable: mediaVolume.configurable,
+            enumerable: mediaVolume.enumerable,
+            get: mediaVolume.get,
+            set(value) {
+                mediaBaseVolumes.set(this, clampVolume(value));
+                trackedMedia.add(this);
+                mediaVolume.set.call(this, clampVolume(value) * masterVolume);
+            },
+        });
+
+        HTMLMediaElement.prototype.play = function(...args) {
+            rememberMediaVolume(this);
+            applyMediaVolume(this);
+            return mediaPlay.apply(this, args);
+        };
+
+        const nativeCreateElement = document.createElement.bind(document);
+        document.createElement = function(localName, ...args) {
+            const element = nativeCreateElement(localName, ...args);
+            if (String(localName).toLowerCase() === "audio" ||
+                String(localName).toLowerCase() === "video") {
+                registerMedia(element);
+            }
+            return element;
+        };
+
+        document.querySelectorAll("audio, video").forEach(registerMedia);
+        if (typeof TARDQUEST_MUSIC_TRACKS !== "undefined") {
+            registerCollection(TARDQUEST_MUSIC_TRACKS);
+        }
+        if (typeof sfx !== "undefined") {
+            registerCollection(sfx);
+        }
+        if (typeof sfxAmb !== "undefined") {
+            registerCollection(sfxAmb);
+        }
+    }
+
+    const nativeConnect = window.AudioNode?.prototype?.connect;
+    const masterGainRecords = new Set();
+
+    if (typeof nativeConnect === "function") {
+        const getMasterGain = context => {
+            const existingRecord = [...masterGainRecords]
+                .find(record => record.context === context);
+            if (existingRecord) {
+                return existingRecord.gain;
+            }
+
+            const gain = context.createGain();
+            gain.gain.value = masterVolume;
+            nativeConnect.call(gain, context.destination);
+
+            const record = { context, gain };
+            masterGainRecords.add(record);
+            return gain;
+        };
+
+        window.AudioNode.prototype.connect = function(destination, ...args) {
+            const context = this.context;
+            if (context && destination === context.destination) {
+                const masterGain = getMasterGain(context);
+                if (this !== masterGain) {
+                    return nativeConnect.call(this, masterGain, ...args);
+                }
+            }
+
+            return nativeConnect.call(this, destination, ...args);
+        };
+    }
+
+    const setMasterVolume = value => {
+        masterVolume = clampVolume(value);
+
+        trackedMedia.forEach(applyMediaVolume);
+        masterGainRecords.forEach(record => {
+            record.gain.gain.value = masterVolume;
+        });
+    };
+
+    window.addEventListener("message", event => {
+        if (
+            event.source !== window.parent ||
+            event.data?.type !== "tardquest-set-master-volume"
+        ) {
+            return;
+        }
+
+        setMasterVolume(event.data.value);
+    });
+})();

--- a/HttpData/AppData/scripts/audio.js
+++ b/HttpData/AppData/scripts/audio.js
@@ -1,0 +1,59 @@
+(() => {
+    const volumeStorageKey = "tardquest-shell-master-volume";
+    const volumeSlider = document.getElementById("audioVolume");
+    const volumeValue = document.getElementById("audioVolumeValue");
+    const gameFrame = document.getElementById("gameFrame");
+
+    if (!volumeSlider || !volumeValue || !gameFrame) {
+        return;
+    }
+
+    const clampPercent = value => Math.min(100, Math.max(0, Number(value) || 0));
+
+    const bridgeSource = fetch("scripts/audio-bridge.js")
+        .then(response => {
+            if (!response.ok) {
+                throw new Error(`Audio bridge request failed: ${response.status}`);
+            }
+            return response.text();
+        });
+
+    async function installAudioBridge() {
+        try {
+            const source = await bridgeSource;
+            gameFrame.contentWindow?.eval(source);
+            sendVolumeToGame();
+        } catch (error) {
+            console.error("Unable to install the game audio bridge:", error);
+        }
+    }
+
+    function sendVolumeToGame() {
+        gameFrame.contentWindow?.postMessage(
+            {
+                type: "tardquest-set-master-volume",
+                value: clampPercent(volumeSlider.value) / 100,
+            },
+            "*"
+        );
+    }
+
+    function updateVolume(value) {
+        const percent = clampPercent(value);
+        volumeSlider.value = percent;
+        volumeValue.textContent = `${percent}%`;
+        localStorage.setItem(volumeStorageKey, String(percent));
+        sendVolumeToGame();
+    }
+
+    const savedVolume = localStorage.getItem(volumeStorageKey);
+    updateVolume(savedVolume === null ? volumeSlider.value : savedVolume);
+
+    volumeSlider.addEventListener("input", event => {
+        updateVolume(event.target.value);
+    });
+
+    gameFrame.addEventListener("load", sendVolumeToGame);
+    gameFrame.addEventListener("load", installAudioBridge);
+    installAudioBridge();
+})();

--- a/HttpData/AppData/scripts/titlebar.js
+++ b/HttpData/AppData/scripts/titlebar.js
@@ -70,8 +70,9 @@ function resizeFrame() {
     const aspectRatio = originalWidth / originalHeight;
     
     // Calculate available space
-    const titlebarHeight = 20;
-    const toolbarHeight = 23;
+    const controlsHidden = document.body.classList.contains('fullscreen-controls-hidden');
+    const titlebarHeight = controlsHidden ? 0 : 20;
+    const toolbarHeight = controlsHidden ? 0 : 23;
     const borderWidth = 4; // Your body border
     
     const availableWidth = window.innerWidth - (borderWidth * 2);
@@ -92,9 +93,52 @@ function resizeFrame() {
     iframe.style.transformOrigin = 'top center';
 }
 
+let controlsHideTimeout;
+
+function setFullscreenMode(isFullscreen) {
+    document.body.classList.toggle('fullscreen-mode', isFullscreen);
+    document.body.classList.toggle('fullscreen-controls-hidden', isFullscreen);
+    resizeFrame();
+}
+
+function showFullscreenControls() {
+    clearTimeout(controlsHideTimeout);
+    document.body.classList.remove('fullscreen-controls-hidden');
+    resizeFrame();
+}
+
+function hideFullscreenControls() {
+    if (document.body.classList.contains('fullscreen-mode')) {
+        document.body.classList.add('fullscreen-controls-hidden');
+        resizeFrame();
+    }
+}
+
+function setupFullscreenControls() {
+    window.electronAPI.onFullscreenChange((_event, isFullscreen) => {
+        setFullscreenMode(isFullscreen);
+    });
+
+    window.electronAPI.isFullscreen().then(setFullscreenMode);
+
+    document.addEventListener('mousemove', (event) => {
+        if (!document.body.classList.contains('fullscreen-mode')) {
+            return;
+        }
+
+        if (event.clientY <= 12) {
+            showFullscreenControls();
+        } else if (!document.body.classList.contains('fullscreen-controls-hidden')) {
+            clearTimeout(controlsHideTimeout);
+            controlsHideTimeout = setTimeout(hideFullscreenControls, 630);
+        }
+    });
+}
+
 // Load saved border on page load
 window.addEventListener('load', function() {
     loadSavedBorder();
+    setupFullscreenControls();
     resizeFrame();
 });
 

--- a/HttpData/AppData/scripts/titlebar.js
+++ b/HttpData/AppData/scripts/titlebar.js
@@ -107,8 +107,22 @@ function showFullscreenControls() {
     resizeFrame();
 }
 
+function scheduleFullscreenControlsHide() {
+    clearTimeout(controlsHideTimeout);
+    if (!document.body.classList.contains('fullscreen-mode')) {
+        return;
+    }
+
+    controlsHideTimeout = setTimeout(hideFullscreenControls, 630);
+}
+
+function isToolbarDropdownFocused() {
+    const activeElement = document.activeElement;
+    return activeElement instanceof HTMLSelectElement && activeElement.closest('.toolbar-strip') !== null;
+}
+
 function hideFullscreenControls() {
-    if (document.body.classList.contains('fullscreen-mode')) {
+    if (document.body.classList.contains('fullscreen-mode') && !isToolbarDropdownFocused()) {
         document.body.classList.add('fullscreen-controls-hidden');
         resizeFrame();
     }
@@ -121,6 +135,14 @@ function setupFullscreenControls() {
 
     window.electronAPI.isFullscreen().then(setFullscreenMode);
 
+    document.querySelectorAll('.toolbar-strip select').forEach((dropdown) => {
+        dropdown.addEventListener('focus', showFullscreenControls);
+        dropdown.addEventListener('pointerdown', showFullscreenControls);
+        dropdown.addEventListener('keydown', showFullscreenControls);
+        dropdown.addEventListener('blur', scheduleFullscreenControlsHide);
+        dropdown.addEventListener('change', scheduleFullscreenControlsHide);
+    });
+
     document.addEventListener('mousemove', (event) => {
         if (!document.body.classList.contains('fullscreen-mode')) {
             return;
@@ -129,8 +151,7 @@ function setupFullscreenControls() {
         if (event.clientY <= 12) {
             showFullscreenControls();
         } else if (!document.body.classList.contains('fullscreen-controls-hidden')) {
-            clearTimeout(controlsHideTimeout);
-            controlsHideTimeout = setTimeout(hideFullscreenControls, 630);
+            scheduleFullscreenControlsHide();
         }
     });
 }

--- a/HttpData/AppData/style.css
+++ b/HttpData/AppData/style.css
@@ -228,10 +228,71 @@ iframe#gameFrame {
 .border-selector,
 .filter-selector,
 .online-selector,
-.dev-selector {
+.dev-selector,
+.audio-volume-selector {
     -webkit-app-region: no-drag;
     margin-left: 0;
     padding-left: 0;
+}
+
+.audio-volume-selector {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-left: auto;
+    margin-right: 4px;
+    height: 21px;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.audio-volume-label {
+    font-size: 12px;
+    color: #000000;
+    text-shadow: none;
+}
+
+.audio-volume {
+    appearance: none;
+    width: 94px;
+    height: 16px;
+    margin: 0;
+    padding: 0;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+}
+
+.audio-volume::-webkit-slider-runnable-track {
+    height: 6px;
+    background: #808080;
+    border-top: solid 1px #404040;
+    border-bottom: solid 1px #eeeeee;
+}
+
+.audio-volume::-webkit-slider-thumb {
+    appearance: none;
+    width: 30px;
+    height: 14px;
+    margin-top: -5px;
+    background: linear-gradient(to right, #eeeeee 0%, #b1b1b1 100%);
+    border: outset 2px #b1b1b1;
+    box-sizing: border-box;
+}
+
+.audio-volume:active::-webkit-slider-thumb {
+    border-style: inset;
+    background: #d6d6d6;
+}
+
+.audio-volume:focus {
+    outline: 1px dotted #000000;
+    outline-offset: 1px;
+}
+
+.audio-volume-value {
+    min-width: 30px;
+    text-align: right;
 }
 
 /* ============================Retro Filter================================= */

--- a/HttpData/AppData/style.css
+++ b/HttpData/AppData/style.css
@@ -48,6 +48,11 @@ iframe#gameFrame {
     overflow: hidden;
 }
 
+.fullscreen-mode.fullscreen-controls-hidden .main-content {
+    height: 100%;
+    margin-top: 0;
+}
+
 /* ============================== Titlebar =============================== */
 
 .toolbar-strip {
@@ -64,6 +69,7 @@ iframe#gameFrame {
     border: inset 2px;
     margin-left: 4px;
     margin-right: 4px;
+    transition: transform 0.275s ease, opacity 0.275s ease;
 }
 
 .custom-titlebar {
@@ -80,6 +86,19 @@ iframe#gameFrame {
     padding: 0px;
     user-select: none;
     box-shadow: #0000006b 0px 0px 0px 5px;
+    transition: transform 0.275s ease, opacity 0.275s ease;
+}
+
+.fullscreen-controls-hidden .custom-titlebar {
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-100%);
+}
+
+.fullscreen-controls-hidden .toolbar-strip {
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-45px);
 }
 
 .custom-titlebar-logo {

--- a/main.js
+++ b/main.js
@@ -8,7 +8,7 @@ import { readFileSync, writeFileSync } from 'fs';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const publicDir = path.join(__dirname, 'HttpData');
 const windowStatePath = path.join(app.getPath('userData'), 'window-state.json');
-const defaultWindowState = { width: 1280, height: 720 };
+const defaultWindowState = { width: 1280, height: 720, fullscreen: true };
 const minimumWindowState = { width: 604, height: 600 };
 
 const MIME_TYPES = {
@@ -44,7 +44,8 @@ function loadWindowState() {
         const savedState = JSON.parse(readFileSync(windowStatePath, 'utf8'));
         return {
             width: Math.max(minimumWindowState.width, Number(savedState.width) || defaultWindowState.width),
-            height: Math.max(minimumWindowState.height, Number(savedState.height) || defaultWindowState.height)
+            height: Math.max(minimumWindowState.height, Number(savedState.height) || defaultWindowState.height),
+            fullscreen: savedState.fullscreen !== false
         };
     } catch {
         return defaultWindowState;
@@ -52,16 +53,16 @@ function loadWindowState() {
 }
 
 function saveWindowState(win) {
-    if (win.isFullScreen()) {
-        return;
-    }
-
-    const bounds = win.isMaximized() ? win.getNormalBounds() : win.getBounds();
+    const isFullscreen = win.isFullScreen();
+    const bounds = win.isMaximized() || isFullscreen
+        ? win.getNormalBounds()
+        : win.getBounds();
 
     try {
         writeFileSync(windowStatePath, JSON.stringify({
             width: bounds.width,
-            height: bounds.height
+            height: bounds.height,
+            fullscreen: isFullscreen
         }));
     } catch (error) {
         console.error('Unable to save window state:', error);
@@ -96,7 +97,7 @@ const createWindow = () => {
         autoHideMenuBar: true,
         frame: false,
         roundedCorners: false,
-        fullscreen: true,
+        show: false,
         webPreferences: {
             preload: path.join(__dirname, 'preload.js'),
             contextIsolation: true,
@@ -105,6 +106,15 @@ const createWindow = () => {
             sandbox: false
         }
     });
+
+    let windowStateSaveTimeout;
+    const scheduleWindowStateSave = () => {
+        clearTimeout(windowStateSaveTimeout);
+        windowStateSaveTimeout = setTimeout(() => {
+            windowStateSaveTimeout = null;
+            saveWindowState(win);
+        }, 250);
+    };
 
     // Handle window controls from renderer
     ipcMain.handle('window-minimize', () => win.minimize());
@@ -132,10 +142,19 @@ const createWindow = () => {
     win.on('leave-full-screen', () => {
         win.webContents.send('fullscreen-changed', false);
     });
-    win.on('resize', () => saveWindowState(win));
-    win.on('close', () => saveWindowState(win));
+    win.on('resize', scheduleWindowStateSave);
+    win.on('close', () => {
+        clearTimeout(windowStateSaveTimeout);
+        saveWindowState(win);
+    });
 
     win.loadURL('app://tard.quest/AppData/index.html');
+    win.once('ready-to-show', () => {
+        if (windowState.fullscreen) {
+            win.setFullScreen(true);
+        }
+        win.show();
+    });
 };
 
 app.whenReady().then(() => {

--- a/main.js
+++ b/main.js
@@ -3,9 +3,13 @@ import { BrowserWindow, app, ipcMain, protocol } from 'electron';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { readFile } from 'fs/promises';
+import { readFileSync, writeFileSync } from 'fs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const publicDir = path.join(__dirname, 'HttpData');
+const windowStatePath = path.join(app.getPath('userData'), 'window-state.json');
+const defaultWindowState = { width: 1280, height: 720 };
+const minimumWindowState = { width: 604, height: 600 };
 
 const MIME_TYPES = {
     '.html': 'text/html',
@@ -35,6 +39,35 @@ function getMimeType(filePath) {
     return MIME_TYPES[path.extname(filePath).toLowerCase()] || 'application/octet-stream';
 }
 
+function loadWindowState() {
+    try {
+        const savedState = JSON.parse(readFileSync(windowStatePath, 'utf8'));
+        return {
+            width: Math.max(minimumWindowState.width, Number(savedState.width) || defaultWindowState.width),
+            height: Math.max(minimumWindowState.height, Number(savedState.height) || defaultWindowState.height)
+        };
+    } catch {
+        return defaultWindowState;
+    }
+}
+
+function saveWindowState(win) {
+    if (win.isFullScreen()) {
+        return;
+    }
+
+    const bounds = win.isMaximized() ? win.getNormalBounds() : win.getBounds();
+
+    try {
+        writeFileSync(windowStatePath, JSON.stringify({
+            width: bounds.width,
+            height: bounds.height
+        }));
+    } catch (error) {
+        console.error('Unable to save window state:', error);
+    }
+}
+
 // Register custom scheme before app is ready
 protocol.registerSchemesAsPrivileged([
     {
@@ -54,11 +87,12 @@ protocol.registerSchemesAsPrivileged([
 app.commandLine.appendSwitch('no-sandbox');
 
 const createWindow = () => {
+    const windowState = loadWindowState();
     const win = new BrowserWindow({
-        width: 1280,
-        height: 720,
-        minWidth: 604,
-        minHeight: 600,
+        width: windowState.width,
+        height: windowState.height,
+        minWidth: minimumWindowState.width,
+        minHeight: minimumWindowState.height,
         autoHideMenuBar: true,
         frame: false,
         roundedCorners: false,
@@ -82,6 +116,7 @@ const createWindow = () => {
         }
     });
     ipcMain.handle('window-close', () => win.close());
+    ipcMain.handle('window-is-fullscreen', () => win.isFullScreen());
     ipcMain.handle('window-fullscreen', () => {
         if (win.isFullScreen()) {
             win.setFullScreen(false);
@@ -97,6 +132,8 @@ const createWindow = () => {
     win.on('leave-full-screen', () => {
         win.webContents.send('fullscreen-changed', false);
     });
+    win.on('resize', () => saveWindowState(win));
+    win.on('close', () => saveWindowState(win));
 
     win.loadURL('app://tard.quest/AppData/index.html');
 };

--- a/preload.js
+++ b/preload.js
@@ -5,5 +5,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
     maximizeWindow: () => ipcRenderer.invoke('window-maximize'),
     closeWindow: () => ipcRenderer.invoke('window-close'),
     toggleFullscreen: () => ipcRenderer.invoke('window-fullscreen'),
+    isFullscreen: () => ipcRenderer.invoke('window-is-fullscreen'),
     onFullscreenChange: (callback) => ipcRenderer.on('fullscreen-changed', callback)
 });


### PR DESCRIPTION
## Hewwo, dungeon dewvew

TardQuest has weceived some vewy impowtant bwain upgwades, uwu.

## What's new, nya

- TardQuest wemembews the wast window size.
- TardQuest wemembews if you weft it in fuwwscween ow windowed mode.
- Fwesh launches still begin in fuwwscween, as the ancient pwophecy intended.
- The custom titwebaw and toolbaw swide away duwing fuwwscween.
- Moving the cuwsow to the top edge bwings the contwows back.
- A pewsistent mastew-vowume swidew now wives on the toolbaw.

## Window behaviow, uwu

When you escape fuwwscween into windowed mode, TardQuest wemembews youw choice instead of dwamatically fowgetting it evewy time the app launches.

Youw pwefewwed window dimensions awe wemembewed too.

## Basic testing, nya

1. Wun `npm stawt`.
2. Switch between fuwwscween and windowed mode.
3. Wesize the window, close TardQuest, and launch it again.
4. Move the cuwsow to the top edge while fuwwscween to westowe the contwows.
5. Move the vowume swidew and check that the game audio wesponds.
6. Cwose and weopen the app to check that the vowume setting wemains saved.

## Weview wequest

Pwease inspect the window wemembewing, fuwwscween escape behaviow, and audio swidew.

Once appwoved, this may be weweased upon the unsuspecting dungeon, uwu.